### PR TITLE
Fix QRスタンプ引き継ぎとPWA挙動: index→collect転送 + SW修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,18 +651,10 @@
                 const stampParam = urlParams.get('stamp');
                 
                 if (stampParam) {
-                    // index.htmlにstampパラメータが来るのは通常ありえない
-                    // collect.htmlを使うべきなので、警告を出す
-                    log(`警告: index.htmlにstampパラメータが渡されました: stamp=${stampParam}`);
-                    log(`正しいURL: collect.html?stamp=${stampParam}`);
-                    
-                    // URLをクリーンにする（パラメータを削除）
-                    const cleanUrl = window.location.origin + window.location.pathname;
-                    window.history.replaceState({}, document.title, cleanUrl);
-                    
-                    // collect.htmlにリダイレクトする
-                    // window.location.href = `collect.html?stamp=${stampParam}`;
-                    // return;
+                    // index.htmlでstampパラメータを受け取ったらcollect.htmlへリダイレクト
+                    log(`index.htmlにstampパラメータを検出: ${stampParam} -> collect.htmlに転送`);
+                    window.location.replace(`collect.html?stamp=${encodeURIComponent(stampParam)}`);
+                    return;
                 }
                 
                 // セッションストレージからペンディングスタンプを復元

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,10 @@
 // Service Worker for AR Stamp Rally PWA
-const CACHE_NAME = 'ar-stamp-v2';
+const CACHE_NAME = 'ar-stamp-v3';
 const BASE_URL = '/ar-stamp-rallybeta/';
 const urlsToCache = [
   BASE_URL,
   BASE_URL + 'index.html',
+  BASE_URL + 'collect.html',
   BASE_URL + 'nisyama1.png',
   BASE_URL + 'manifest.json',
   'https://aframe.io/releases/1.4.0/aframe.min.js'
@@ -43,38 +44,7 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
   const url = new URL(event.request.url);
   
-  // スタンプパラメータ付きのURLの場合
-  if (url.pathname.includes('/ar-stamp-rallybeta') && url.searchParams.has('stamp')) {
-    // パラメータを保持したままindex.htmlを返す
-    event.respondWith(
-      caches.match(BASE_URL + 'index.html')
-        .then(response => {
-          if (response) {
-            // キャッシュされたindex.htmlを返す
-            // JavaScriptがパラメータを処理する
-            return response;
-          }
-          // キャッシュにない場合はネットワークから取得
-          return fetch(BASE_URL + 'index.html')
-            .then(response => {
-              // 成功したらキャッシュに追加
-              if (response && response.status === 200) {
-                const responseToCache = response.clone();
-                caches.open(CACHE_NAME)
-                  .then(cache => {
-                    cache.put(BASE_URL + 'index.html', responseToCache);
-                  });
-              }
-              return response;
-            });
-        })
-        .catch(() => {
-          // オフライン時もindex.htmlを返す
-          return caches.match(BASE_URL + 'index.html');
-        })
-    );
-    return;
-  }
+
   
   // 通常のリクエスト処理
   event.respondWith(


### PR DESCRIPTION
主な修正点:
- index.htmlでstampパラメータ検出時はcollect.htmlへ即時リダイレクト
- Service Workerがstamp付きURLをindex.htmlに差し替えないようにロジック削除
- SWキャッシュ名をv3へ上げ、collect.htmlも事前キャッシュ
- これにより、QRリンク(collect.html?stamp=...)→collect→localStorage保存→一覧は同一タブで機能

確認方法:
1. https://kurumayu1043-tech.github.io/ar-stamp-rallybeta/simple-test.html を開きlocalStorageをクリア
2. 各ボタンからcollect.htmlを新規タブで開き、タイトル/アイコン/カウントが正しくなるか
3. 既存のQR(collect.html?stamp=xxx)で入場口固定になる事象が改善するか

注意: 以前のSWが残っている端末は、リロード2回 or 設定からサイトデータ削除を実施してください。